### PR TITLE
Docs: link to CoCivium canonicals (tag migration-20250908-0133)

### DIFF
--- a/admin/bpoe/crosslinking-checklist.md
+++ b/admin/bpoe/crosslinking-checklist.md
@@ -1,0 +1,8 @@
+# BPOE: Cross-linking pass (Civium canonicals)
+
+**Goal:** Every entry point points to CoCivium canonicals pinned to a release tag.
+
+- Maintain `docs/Civium-Canonicals.md` (CoModules) and glossary “See also” (GIBindex).
+- Append “Canonical References” to README where relevant.
+- Prefer tag-pinned links for provenance; bump tag only during explicit migration.
+- Rebase rule: keep canonicals from `main` (`git checkout --ours <path>`); accept net-new only.


### PR DESCRIPTION
Adds stable pointers to PREAMBLE and Core Assumption.