### PR TITLE
Seed best practices docs

### DIFF
--- a/docs/best-practices/ai-ethics/ai_ethics_best_practices.md
+++ b/docs/best-practices/ai-ethics/ai_ethics_best_practices.md
@@ -1,0 +1,8 @@
+# AI Ethics — Best Practices
+
+- Transparency: all automation visible in repo/workflows.
+- Autonomy: always include human override and opt-out.
+- Non-coercion: advice must be suggestion, never enforcement.
+- Fairness: use diverse, global training sets; avoid vendor lock-in.
+- Auditability: maintain decision logs for inspection.
+- Congruence: align with CoCivium's principles of openness + autonomy.

--- a/docs/best-practices/career/career_best_practices.md
+++ b/docs/best-practices/career/career_best_practices.md
@@ -1,0 +1,9 @@
+# CareerOS — Best Practices (generic, evidence-based)
+
+- Use **evidence-based career models**:
+  - Holland Codes (RIASEC) for interests
+  - O*NET labor market data
+  - Skill taxonomies aligned with ISO/ESCO frameworks
+- Always expose weighting (salary, security, passion, growth).
+- Include refusal paths: "not for me" should improve personalization.
+- Audit AI advice: retain logs for transparency.

--- a/docs/best-practices/life/life_best_practices.md
+++ b/docs/best-practices/life/life_best_practices.md
@@ -1,0 +1,10 @@
+# LifeOS — Best Practices (generic, wellbeing)
+
+- Adopt **WHO and OECD wellbeing frameworks**:
+  - Food environment (healthy default choices)
+  - Physical activity (150min/week baseline)
+  - Sleep hygiene
+  - Social connectedness
+- No predatory nudges (no affiliate sales).
+- Local-first data; encrypted at rest.
+- Track outcomes (energy, mood, labs) not vanity metrics.


### PR DESCRIPTION
Adds evidence-based starter notes for careerOS, lifeOS, and AI ethics.